### PR TITLE
node now returns headers in array breaking tobi

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -178,7 +178,9 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
 
     // Cookies
     if (res.headers['set-cookie']) {
-      self.cookieJar.add(new Cookie(res.headers['set-cookie']));
+      res.headers['set-cookie'].forEach(function(cookie) {
+        self.cookieJar.add(new Cookie(cookie));
+      });
     }
 
     // Success


### PR DESCRIPTION
At least in v0.4.4 of node.js res.headers['set-cookie'] returns an array and not a string anymore which breaks tobi.
