### PR TITLE
Add HTTP 204 support.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -187,6 +187,11 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
     // Success
     if (status >= 200 && status < 300) {
       var contentType = res.headers['content-type'];
+ 
+      // Some responses, such as 204, do not have this header
+      if (!contentType) {
+        return fn(res);
+      }
 
       // JSON support
       if (~contentType.indexOf('json')) {


### PR DESCRIPTION
HTTP 204 responses do not have a content-type header (at least as handled by Express), this commit adds a check for that header before trying to use it.
