### PR TITLE
Test framework hangs on error status codes

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -228,7 +228,9 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
       self.request('GET', path, options, fn);
     // Error
     } else {
-      fn(res);
+      res.on('end', function() {
+        fn(res);
+      });
     }
   });
 


### PR DESCRIPTION
Some test frameworks (at least cucumis) hang when tobi doesn't consume the 'end' event on status codes indicating errors (>=400).
