### PR TITLE
Hi, I added an option Browser#followRedirects so that you can avoid automatically following all redirects

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -49,6 +49,7 @@ var Browser = module.exports = exports = function Browser(html, options, c) {
   this.external = options.external;
   this.history = [];
   this.cookieJar = new CookieJar;
+  this.followRedirects = true;
 
   // Client types
   if ('number' == typeof html) {
@@ -225,7 +226,11 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
       var location = res.headers.location
         , path = url.parse(location).pathname;
       self.emit('redirect', location);
-      self.request('GET', path, options, fn);
+      if (self.followRedirects) {
+        self.request('GET', path, options, fn);
+      } else {
+        return fn(res);
+      }
     // Error
     } else {
       fn(res);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     , "jsdom": ">= 0.0.1"
     , "qs": ">= 0.0.1"
     , "should": ">= 0.0.1"
+    , "connect": ">= 0.0.1"
   }
   , "main": "./index.js"
   , "engines": { "node": "0.4.x" }

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -229,6 +229,17 @@ module.exports = {
       done();
     });
   },
+  
+  'test .request() redirect when followRedirects is false': function(done) {
+    var browser = tobi.createBrowser(app);
+    browser.followRedirects = false;
+    browser.request('GET', '/redirect', {}, function(res, $){
+      res.should.have.status(302);
+      browser.should.have.property('path', '/redirect');
+      browser.history.should.eql(['/redirect']);
+      done();
+    });
+  },
 
   // [!] if this test doesn't pass, an uncaught ECONNREFUSED will be shown
   'test .request() on deferred listen()': function(done){


### PR DESCRIPTION
I did this so I can test a path in my app that redirects to an external service (twitter oauth) without causing the test to actually request the page from twitter.

I also added a devDependency for connect, which is loaded here:
https://github.com/bantic/tobi/blob/master/test/scenarios.login.test.js#L7

thanks!
Cory
