### PR TITLE
Include Activated Submit Buttons as Successful Controls.

### DIFF
--- a/lib/jquery/index.js
+++ b/lib/jquery/index.js
@@ -98,10 +98,11 @@ module.exports = function(browser, $){
           form.defaultSelectOptions();
           method = form.attr('method') || 'get';
           url = form.attr('action') || parse($.browser.path).pathname;
+          var body = $.param(form.serializeArray().concat([{"name" : this[0].name, "value" : this[0].value }]));
           if ('get' == method) {
-            url += '?' + form.serialize();
+            url += '?' + body;
           } else  {
-            options.body = form.serialize();
+            options.body = body;
             options.headers = {
               'Content-Type': 'application/x-www-form-urlencoded'
             };

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -89,7 +89,7 @@ app.get('/form', function(req, res){
     + '<input id="user-email" type="text" name="user[email]" disabled="disabled" />'
     + '<input type="checkbox" name="user[agreement]" id="user-agreement" value="yes" />'
     + '<input type="checkbox" name="user[subscribe]" checked="checked" value="yes" />'
-    + '<input type="submit" value="Update" />'
+    + '<input type="submit" name="update" value="Update" />'
     + '<fieldset>'
     + '  <select name="user[forum_digest]">'
     + '    <option value="none">None</option>'
@@ -501,6 +501,7 @@ module.exports = {
             , subscribe: 'yes'
             , signature: ''
             , forum_digest: 'none'
+            , update: 'Update'
           }
         });
         done();
@@ -522,6 +523,7 @@ module.exports = {
             , subscribe: 'yes'
             , signature: ''
             , forum_digest: 'none'
+            , update: 'Update'
           }
         });
         done();
@@ -546,6 +548,7 @@ module.exports = {
             , subscribe: 'yes'
             , signature: ''
             , forum_digest: 'none'
+            , update: 'Update'
           }
         });
         done();
@@ -575,6 +578,7 @@ module.exports = {
             , signature: 'TJ Holowaychuk'
             , display_signature: 'No'
             , forum_digest: 'daily'
+            , update: 'Update'
           }
         });
         done();
@@ -604,6 +608,7 @@ module.exports = {
             , signature: 'TJ Holowaychuk'
             , display_signature: 'No'
             , forum_digest: 'daily'
+            , update: 'Update'
           }
         });
         done();


### PR DESCRIPTION
When forms are submitted by clicking on a submit input, the name/value of the submit input should be submitted along with the form. This is line with specification from the W3C: http://www.w3.org/TR/html401/interact/forms.html#h-17.13.2 as well as how jQueries own $("form input[type=subit]").click() would behave.

This pull request does cause another test to fail. I'm not sure its a bad thing, just an object difference caused by the differences in serializing the the forms specifically:

```
uncaught: AssertionError: expected { query: 'foo bar', '=': '' } to equal { query: 'foo bar' }
```
