### PR TITLE
Default to setting Content-Type when Browser#post options includes body. 

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -158,6 +158,7 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
   // Request body
   if (options.body) {
     headers['Content-Length'] = options.body.length;
+    headers['Content-Type']   = headers['Content-Type'] || 'application/x-www-form-urlencoded';
   }
 
   // Request

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -294,6 +294,17 @@ module.exports = {
     });
   },
   
+  'test .post(path) with passed body': function(done) {
+    var browser = tobi.createBrowser(app);
+    browser.post('/form', {body: "foo=bar"}, function(res, $){
+      res.should.have.status(200);
+      res.body.body.should.eql({foo:"bar"});
+      browser.should.have.property('path', '/form');
+      browser.history.should.eql(['/form']);
+      done();
+    });
+  },
+  
   'test .put(path)': function(done){
     var browser = tobi.createBrowser(app);
     browser.put('/', function(res, $){


### PR DESCRIPTION
Default to setting Content-Type when Browser#post options includes body. Default is 'application/x-www-form-urlencoded'

This seems to be the intended behavior when making a Browser#post call, because in the README it includes this code block:

```
browser.post('/login', { body: 'foo=bar' }, function(res, $){

});
```

Unless that includes also explicitly sets the content-type to  'application/x-www-form-urlencoded', though, express (at least) won't recognize the body.
This commit by default sets the headers['Content-Type'] to  'application/x-www-form-urlencoded' if options.body is present (and headers['Content-Type'] wasn't explicitly set).
