### PR TITLE
Allow passing a hash instead of a string in Browser#post's options.body.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -157,6 +157,15 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
 
   // Request body
   if (options.body) {
+    if ("string" !== typeof options.body) {
+      var options_array = [];
+      for (var key in options.body) {
+        if (options.body.hasOwnProperty(key)) {
+          options_array.push( escape(key) + "=" + escape(options.body[key]) );
+        }
+      }
+      options.body = options_array.join("&");
+    }
     headers['Content-Length'] = options.body.length;
     headers['Content-Type']   = headers['Content-Type'] || 'application/x-www-form-urlencoded';
   }

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -305,6 +305,17 @@ module.exports = {
     });
   },
   
+  'test .post(path) with passed body as a hash': function(done) {
+    var browser = tobi.createBrowser(app);
+    browser.post('/form', {body: {foo: "b&r", bar: "foo"}}, function(res, $){
+      res.should.have.status(200);
+      res.body.body.should.eql({foo:"b&r", bar: "foo"});
+      browser.should.have.property('path', '/form');
+      browser.history.should.eql(['/form']);
+      done();
+    });
+  },
+  
   'test .put(path)': function(done){
     var browser = tobi.createBrowser(app);
     browser.put('/', function(res, $){


### PR DESCRIPTION
One more...

This changes it so that the "body" option for Browser.post can be a hash rather than a string. Makes tobi easier to use this way (before this I was having to properly escape the string by hand).

Allows one to do:

```
browser.post('/login', { body: {foo:"b&r",bar:"foo"} }, function(res, $){

});
```

The test includes the text "b&r" to ensure that the escaping is being done properly.

thanks.
