### PR TITLE
Fix for selecting multiple select options test.

### DIFF
--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -91,7 +90,7 @@ app.get('/form', function(req, res){
     + '<input type="checkbox" name="user[subscribe]" checked="checked" value="yes" />'
     + '<input type="submit" name="update" value="Update" />'
     + '<fieldset>'
-    + '  <select name="user[forum_digest]">'
+    + '  <select name="user[forum_digest]" size="2" multiple>'
     + '    <option value="none">None</option>'
     + '    <option value="daily">Once per day</option>'
     + '    <option value="weekly">Once per week</option>'


### PR DESCRIPTION
Fix for issue: https://github.com/LearnBoost/tobi/issues/39.  From what I can see, given the markup, the failure is what is supposed to happen. Multiple options can't be selected on a select box unless it is given the multiple attribute.

This test should never have passed, unless something in JSDOM changed to only allow multiple selection if the "multiple" attribute is present?
