### PR TITLE
Use qs stringify for post body

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -158,7 +158,7 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
 
   // Request body
   if (options.body) {
-    if (typeof options.body === 'object') {
+    if ('[object Object]' === Object.prototype.toString.call(options.body)) {
       options.body = qs.stringify(options.body);
     }
     headers['Content-Length'] = options.body.length;

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -15,7 +15,8 @@ var EventEmitter = require('events').EventEmitter
   , jsdom = require('jsdom')
   , jQuery = require('./jquery/core')
   , url = require('url')
-  , http = require('http');
+  , http = require('http')
+  , qs = require('qs');
 
 /**
  * Starting portno.
@@ -157,6 +158,9 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
 
   // Request body
   if (options.body) {
+    if (typeof options.body === 'object') {
+      options.body = qs.stringify(options.body);
+    }
     headers['Content-Length'] = options.body.length;
     headers['Content-Type']   = headers['Content-Type'] || 'application/x-www-form-urlencoded';
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
       "jsdom": ">= 0.1.21"
     , "htmlparser": ">= 1.7.3"
     , "should": ">= 0.0.4"
-    , "qs": ">= 0.1.0"
+    , "qs": ">= 0.2.0"
   }
   , "devDependencies": {
       "express": "2.3.x"

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -294,11 +294,22 @@ module.exports = {
     });
   },
   
-  'test .post(path) with passed body': function(done) {
+  'test .post(path) with passed body string': function(done) {
     var browser = tobi.createBrowser(app);
-    browser.post('/form', {body: "foo=bar"}, function(res, $){
+    browser.post('/form', {body: 'foo=bar'}, function(res, $){
       res.should.have.status(200);
-      res.body.body.should.eql({foo:"bar"});
+      res.body.body.should.eql({foo:'bar'});
+      browser.should.have.property('path', '/form');
+      browser.history.should.eql(['/form']);
+      done();
+    });
+  },
+  
+  'test .post(path) with passed body object': function(done) {
+    var browser = tobi.createBrowser(app);
+    browser.post('/form', {body: {foo:'bar'}}, function(res, $){
+      res.should.have.status(200);
+      res.body.body.should.eql({foo:'bar'});
       browser.should.have.property('path', '/form');
       browser.history.should.eql(['/form']);
       done();


### PR DESCRIPTION
This uses qs.stringify to turn options.body into a string if it is an object in Browser.post.  I am not sure the best way to determine if a variable is an object so I used `Object.prototype.toString.call(options.body)` (which I saw used in node-querystring (https://github.com/visionmedia/node-querystring/blob/master/lib/querystring.js#L17).
