### PR TITLE
Several changes, enabling testing of OAuth Consumer flows

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -114,6 +114,21 @@ Browser.prototype.context = function(selector, fn){
   return this;
 };
 
+Browser.prototype.hostBrowser = function(uri) {
+  var otherHostname = uri.hostname
+    , port = uri.port || 80
+    , browsers = Browser.browsers;
+  if (!browsers) {
+    browsers = Browser.browsers = {};
+  }
+  if (!browsers[this.host]) {
+    browsers[this.host] = this;
+  }
+  return browsers[otherHostname] ||
+    (browsers[otherHostname] = new Browser(port, otherHostname));
+  return otherBrowser.request(method, path, options, fn, saveHistory);
+};
+
 /**
  * Request `path` with `method` and callback `fn(jQuery)`.
  *
@@ -148,21 +163,14 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
     return;
   }
 
-  var uri, port, otherHostname, browsers, otherBrowser;
+  var uri, otherHostname, otherBrowser;
   if (path.substring(0, 4) === 'http') {
     // If we have a full uri, not a uri path, then convert the full uri to a path
     uri = url.parse(path);
     path = uri.pathname + (uri.search || '');
     otherHostname = uri.hostname;
-    if (otherHostname !== host) {
-      port = uri.port || 80;
-      browsers = Browser.browsers;
-      if (!browsers) {
-        browsers = Browser.browsers = {};
-      }
-      if (!browsers[this.host]) browsers[this.host] = this;
-      otherBrowser = browsers[otherHostname] ||
-        (browsers[otherHostname] = new Browser(port, otherHostname));
+    if ((otherHostname !== 'undefined') && (otherHostname !== host)) {
+      otherBrowser = this.hostBrowser(uri);
       return otherBrowser.request(method, path, options, fn, saveHistory);
     }
   }
@@ -240,17 +248,10 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
     } else if (status >= 300 && status < 400) {
       var location = res.headers.location
         , uri = url.parse(location)
-        , path = uri.pathname;
+        , path = uri.pathname + (uri.search || '');
       otherHostname = uri.hostname;
       if ((otherHostname !== 'undefined') && (otherHostname !== self.host)) {
-        port = uri.port || 80;
-        browsers = Browser.browsers;
-        if (!browsers) {
-          browsers = Browser.browsers = {};
-        }
-        if (!browsers[self.host]) browsers[self.host] = self;
-        self = browsers[otherHostname] ||
-          (browsers[otherHostname] = new Browser(port, otherHostname));
+        self = self.hostBrowser(uri);
       }
       self.emit('redirect', location);
       if (self.followRedirects) {

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -162,8 +162,6 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
   }
 
   // Request
-  headers.Host = host;
-
   var req = http.request({
       method: method
     , path: path

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -148,10 +148,19 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
     return;
   }
 
+  var uri, port, otherHostname, otherBrowser;
   if (path.substring(0, 4) === 'http') {
     // If we have a full uri, not a uri path, then convert the full uri to a path
-    var uri = url.parse(path);
+    uri = url.parse(path);
     path = uri.pathname + (uri.search || '');
+    otherHostname = uri.hostname;
+    if (otherHostname !== host) {
+      port = uri.port || 80;
+      Browser.browsers || (Browser.browsers = {});
+      otherBrowser = Browser.browsers[otherHostname] ||
+        (Browser.browsers[otherHostname] = new Browser(port, otherHostname));
+      return otherBrowser.request(method, path, options, fn, saveHistory);
+    }
   }
 
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -118,7 +118,7 @@ Browser.prototype.context = function(selector, fn){
 
 Browser.prototype.hostBrowser = function(uri) {
   var otherHostname = uri.hostname
-    , port = uri.port || (uri.protocol === 'https:' ? 443 : 80)
+    , port = uri.port || (uri.protocol === 'https:' ? 443 : (this.port || 80))
     , browsers = Browser.browsers
     , otherBrowser;
   if (!browsers) {
@@ -176,7 +176,9 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
     uri = url.parse(path);
     path = uri.pathname + (uri.search || '');
     otherHostname = uri.hostname;
-    if ((otherHostname !== 'undefined') && (otherHostname !== host)) {
+    if (otherHostname && 
+        (otherHostname !== 'undefined') && 
+        (otherHostname !== host)) {
       otherBrowser = this.hostBrowser(uri);
       return otherBrowser.request(method, path, options, fn, saveHistory);
     }
@@ -203,7 +205,7 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
   var req = (this.https ? https : http).request({
       method: method
     , path: path
-    , port: this.host ? this.port : server.__port
+    , port: this.host ? this.port : (server && server.__port)
     , host: this.host
     , headers: headers
   });
@@ -260,7 +262,9 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
         , uri = url.parse(location)
         , path = uri.pathname + (uri.search || '');
       otherHostname = uri.hostname;
-      if ((otherHostname !== 'undefined') && (otherHostname !== self.host)) {
+      if (otherHostname && 
+          (otherHostname !== 'undefined') && 
+          (otherHostname !== self.host)) {
         self = self.hostBrowser(uri);
       }
       self.emit('redirect', location);

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -148,6 +148,13 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
     return;
   }
 
+  if (path.substring(0, 4) === 'http') {
+    // If we have a full uri, not a uri path, then convert the full uri to a path
+    var uri = url.parse(path);
+    path = uri.pathname + (uri.search || '');
+  }
+
+
   // Save history
   if (false !== saveHistory) this.history.push(path);
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -148,7 +148,7 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
     return;
   }
 
-  var uri, port, otherHostname, otherBrowser;
+  var uri, port, otherHostname, browsers, otherBrowser;
   if (path.substring(0, 4) === 'http') {
     // If we have a full uri, not a uri path, then convert the full uri to a path
     uri = url.parse(path);
@@ -156,9 +156,13 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
     otherHostname = uri.hostname;
     if (otherHostname !== host) {
       port = uri.port || 80;
-      Browser.browsers || (Browser.browsers = {});
-      otherBrowser = Browser.browsers[otherHostname] ||
-        (Browser.browsers[otherHostname] = new Browser(port, otherHostname));
+      browsers = Browser.browsers;
+      if (!browsers) {
+        browsers = Browser.browsers = {};
+      }
+      if (!browsers[this.host]) browsers[this.host] = this;
+      otherBrowser = browsers[otherHostname] ||
+        (browsers[otherHostname] = new Browser(port, otherHostname));
       return otherBrowser.request(method, path, options, fn, saveHistory);
     }
   }
@@ -235,10 +239,22 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
     // Redirect
     } else if (status >= 300 && status < 400) {
       var location = res.headers.location
-        , path = url.parse(location).pathname;
+        , uri = url.parse(location)
+        , path = uri.pathname;
+      otherHostname = uri.hostname;
+      if ((otherHostname !== 'undefined') && (otherHostname !== self.host)) {
+        port = uri.port || 80;
+        browsers = Browser.browsers;
+        if (!browsers) {
+          browsers = Browser.browsers = {};
+        }
+        if (!browsers[self.host]) browsers[self.host] = self;
+        self = browsers[otherHostname] ||
+          (browsers[otherHostname] = new Browser(port, otherHostname));
+      }
       self.emit('redirect', location);
       if (self.followRedirects) {
-        self.request('GET', path, options, fn);
+        self.request('GET', path, {}, fn);
       } else {
         return fn(res);
       }

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -15,6 +15,7 @@ var EventEmitter = require('events').EventEmitter
   , jsdom = require('jsdom')
   , jQuery = require('./jquery/core')
   , url = require('url')
+  , https = require('https')
   , http = require('http');
 
 /**
@@ -61,6 +62,7 @@ var Browser = module.exports = exports = function Browser(html, options, c) {
   } else {
     this.server = html;
   }
+  this.https = (port === 443);
 };
 
 /**
@@ -116,7 +118,7 @@ Browser.prototype.context = function(selector, fn){
 
 Browser.prototype.hostBrowser = function(uri) {
   var otherHostname = uri.hostname
-    , port = uri.port || 80
+    , port = uri.port || (uri.protocol === 'https:' ? 443 : 80)
     , browsers = Browser.browsers;
   if (!browsers) {
     browsers = Browser.browsers = {};
@@ -190,7 +192,7 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
   }
 
   // Request
-  var req = http.request({
+  var req = (this.https ? https : http).request({
       method: method
     , path: path
     , port: this.host ? this.port : server.__port

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -164,17 +164,13 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
   // Request
   headers.Host = host;
 
-  // HTTP client
-  if (!this.client) {
-    // portno & host supplied
-    if (this.port && this.host) {
-      this.client = http.createClient(this.port, this.host);
-    } else {
-      this.client = http.createClient(server.__port);
-    }
-  }
-
-  var req = this.client.request(method, path, headers);
+  var req = http.request({
+      method: method
+    , path: path
+    , port: this.host ? this.port : server.__port
+    , host: this.host
+    , headers: headers
+  });
   req.on('response', function(res){
     var status = res.statusCode
       , buf = '';

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -119,16 +119,21 @@ Browser.prototype.context = function(selector, fn){
 Browser.prototype.hostBrowser = function(uri) {
   var otherHostname = uri.hostname
     , port = uri.port || (uri.protocol === 'https:' ? 443 : 80)
-    , browsers = Browser.browsers;
+    , browsers = Browser.browsers
+    , otherBrowser;
   if (!browsers) {
     browsers = Browser.browsers = {};
   }
   if (!browsers[this.host]) {
     browsers[this.host] = this;
   }
-  return browsers[otherHostname] ||
-    (browsers[otherHostname] = new Browser(port, otherHostname));
-  return otherBrowser.request(method, path, options, fn, saveHistory);
+  otherBrowser = browsers[otherHostname];
+  if (!otherBrowser) {
+    otherBrowser = 
+    browsers[otherHostname] = new Browser(port, otherHostname);
+    otherBrowser.userAgent = this.userAgent;
+  }
+  return otherBrowser;
 };
 
 /**
@@ -184,6 +189,9 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
   // Cookies
   var cookies = this.cookieJar.cookieString({ url: path });
   if (cookies) headers.Cookie = cookies;
+
+  // User-Agent
+  if (this.userAgent) headers['User-Agent'] = this.userAgent;
 
   // Request body
   if (options.body) {

--- a/lib/jquery/index.js
+++ b/lib/jquery/index.js
@@ -117,7 +117,7 @@ module.exports = function(browser, $){
     if (!url) throw new Error('failed to click ' + locator + ', ' + prop + ' not present');
 
     // Perform request
-    browser[method](url, options, fn);
+    browser[method.toLowerCase()](url, options, fn);
     
     return this;
   };

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -920,13 +920,13 @@ module.exports = {
 
   'test setting user-agent': function(done){
     var browser = tobi.createBrowser(80,'whatsmyuseragent.com');
-    browser.get('/', function(res,$){
+    browser.get('http://whatsmyuseragent.com', function(res,$){
       res.should.have.status(200);
-      $('#MainBox p strong:first').should.have.text('Your User Agent:');
-      browser.userAgent = ' Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30';
+      $('h4:first').should.have.text('');
+      browser.userAgent = 'Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30';
       browser.get('/', function(res,$){
         res.should.have.status(200);
-        $('#MainBox p strong:first').should.have.text('Your User Agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30');
+        $('h4:first').should.have.text('Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30');
         done();
       });
     });

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -271,6 +271,20 @@ module.exports = {
     });
   },
 
+  'test .request() redirect to a full uri with different hostname': function(done){
+    var browser = tobi.createBrowser(80, 'bit.ly')
+    Browser.browsers.should.not.have.property('bit.ly');
+    Browser.browsers.should.not.have.property('node.js');
+    browser.request('GET', 'http://bit.ly/mQETJ8', {}, function (res, $) {
+      res.should.have.status(200);
+      Browser.browsers.should.have.property('bit.ly');
+      Browser.browsers.should.have.property('nodejs.org');
+      var nodeBrowser = Browser.browsers['nodejs.org'];
+      nodeBrowser.jQuery('img[alt="node.js"]').length.should.equal(1);
+      done();
+    });
+  },
+
   // [!] if this test doesn't pass, an uncaught ECONNREFUSED will be shown
   'test .request() on deferred listen()': function(done){
     var browser = tobi.createBrowser(appDeferred)

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -218,6 +218,22 @@ module.exports = {
       });
     });
   },
+
+  'test .request(method, url)': function(done){
+    var browser = tobi.createBrowser(app);
+    browser.request('GET', 'http://127.0.0.1:' + app.__port, {}, function(res, $){
+      res.should.have.status(200);
+      browser.should.have.property('path', '/');
+      browser.history.should.eql(['/']);
+      browser.request('GET', 'http://127.0.0.1:' + app.__port + '/user/0', {}, function(){
+        browser.should.have.property('path', '/user/0');
+        browser.history.should.eql(['/', '/user/0']);
+        browser.should.have.property('source', '<h1>Tobi</h1><p>the ferret</p>');
+        browser.jQuery('p').text().should.equal('the ferret');
+        done();
+      });
+    });
+  },
   
   'test .request() redirect': function(done){
     var browser = tobi.createBrowser(app);

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -917,6 +917,20 @@ module.exports = {
       done(); 
     });
   },
+
+  'test setting user-agent': function(done){
+    var browser = tobi.createBrowser(80,'whatsmyuseragent.com');
+    browser.get('/', function(res,$){
+      res.should.have.status(200);
+      $('#MainBox p strong:first').should.have.text('Your User Agent:');
+      browser.userAgent = ' Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30';
+      browser.get('/', function(res,$){
+        res.should.have.status(200);
+        $('#MainBox p strong:first').should.have.text('Your User Agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30');
+        done();
+      });
+    });
+  },
   
   after: function(){
     app.close();

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -234,6 +234,21 @@ module.exports = {
       });
     });
   },
+
+  'test .request(method, foreignUrl)': function(done){
+    var browser = tobi.createBrowser(app);
+    browser.request('GET', 'http://www.google.com/', {}, function(res, $){
+      res.should.have.status(200);
+      browser.should.not.have.property('path');
+      browser.history.should.be.empty;
+
+      var googBrowser = Browser.browsers['www.google.com']
+      googBrowser.should.have.property('path', '/');
+      googBrowser.history.should.eql(['/']);
+      googBrowser.jQuery('img[alt="Google"]').length.should.equal(1);
+      done();
+    });
+  },
   
   'test .request() redirect': function(done){
     var browser = tobi.createBrowser(app);

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -300,6 +300,16 @@ module.exports = {
     });
   },
 
+  'test .request redirecting from a full non-https uri to a https uri': function(done){
+    var browser = tobi.createBrowser(80, 'bit.ly')
+    browser.request('GET', 'http://bit.ly/jrs5ME', {}, function (res, $) {
+      res.should.have.status(200);
+      var githubBrowser = Browser.browsers['github.com'];
+      githubBrowser.jQuery('#slider .breadcrumb a').should.have.text('tobi');
+      done();
+    });
+  },
+
   // [!] if this test doesn't pass, an uncaught ECONNREFUSED will be shown
   'test .request() on deferred listen()': function(done){
     var browser = tobi.createBrowser(appDeferred)

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -249,6 +249,21 @@ module.exports = {
       done();
     });
   },
+
+  'test .request(method, foreignHttpsUrl)': function(done){
+    var browser = tobi.createBrowser(app);
+    browser.request('GET', 'https://www.github.com/', {}, function(res, $){
+      res.should.have.status(200);
+      browser.should.not.have.property('path');
+      browser.history.should.be.empty;
+
+      var googBrowser = Browser.browsers['github.com']
+      googBrowser.should.have.property('path', '/');
+      googBrowser.history.should.eql(['/']);
+      googBrowser.jQuery('img[alt="github"]').should.not.be.empty;
+      done();
+    });
+  },
   
   'test .request() redirect': function(done){
     var browser = tobi.createBrowser(app);


### PR DESCRIPTION
I patched tobi to test [everyauth](https://github.com/bnoguchi/everyauth)'s Facebook Connect support.

Changes include:
- Submitting `<form>` with `method="POST"` (as opposed to only `method="post"` before)
- Use of node's new `http` `Agent`' over the legacy `Client`
- `https` detection and support
- Make it appear as if one browser can interact with more than 1 hostname (e.g., 1 hostname redirecting to another hostname)
- Ability to specify User-Agent on a `Browser` instance (for use in all requests by that Browser instance)

... with tests to boot. All tests pass.
