### PR TITLE
process body for all pages apart from redirects so body of 404 and other errors may be parsed

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -230,8 +230,23 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
       });
     }
 
-    // Success
-    if (status >= 200 && status < 300) {
+    if (status >= 300 && status < 400) {
+      var location = res.headers.location
+        , uri = url.parse(location)
+        , path = uri.pathname + (uri.search || '');
+      otherHostname = uri.hostname;
+      if (otherHostname && 
+          (otherHostname !== 'undefined') && 
+          (otherHostname !== self.host)) {
+        self = self.hostBrowser(uri);
+      }
+      self.emit('redirect', location);
+      if (self.followRedirects) {
+        self.request('GET', path, {}, fn);
+      } else {
+        return fn(res);
+      }
+    } else {
       var contentType = res.headers['content-type'];
  
       if (!contentType) return fn(res);
@@ -265,27 +280,6 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
           return self.context.find(selector);
         });
       });
-
-    // Redirect
-    } else if (status >= 300 && status < 400) {
-      var location = res.headers.location
-        , uri = url.parse(location)
-        , path = uri.pathname + (uri.search || '');
-      otherHostname = uri.hostname;
-      if (otherHostname && 
-          (otherHostname !== 'undefined') && 
-          (otherHostname !== self.host)) {
-        self = self.hostBrowser(uri);
-      }
-      self.emit('redirect', location);
-      if (self.followRedirects) {
-        self.request('GET', path, {}, fn);
-      } else {
-        return fn(res);
-      }
-    // Error
-    } else {
-      fn(res);
     }
   });
 

--- a/test/assertions.test.js
+++ b/test/assertions.test.js
@@ -56,6 +56,10 @@ app.get('/form', function(req, res){
     + '</form>');
 });
 
+app.get('/404', function(req, res){
+  res.send('<p>page not found</p>', 404);
+});
+
 // Tests
 
 exports['test .text()'] = function(done){
@@ -267,12 +271,33 @@ exports['test .status()'] = function(done){
   });
 };
 
+exports['test .status(404)'] = function(done){
+  browser.get('/404', function(res, $){
+    res.should.have.status(404);
+	$('p').text("page not found");
+    done();
+  });
+};
+
+
 exports['test .header()'] = function(done){
   browser.get('/attrs', function(res, $){
     res.should.have.header('Content-Type', 'text/html; charset=utf-8');
     done();
   });
 };
+exports['test .status()'] = function(done){
+  browser.get('/attrs', function(res, $){
+    res.should.have.status(200);
+
+    err(function(){
+      res.should.have.status(404);
+    }, "expected response code of 404 'Not Found', but got 200 'OK'");
+
+    done();
+  });
+};
+
 
 exports.after = function(){
   app.close();


### PR DESCRIPTION
Currently only the body for a 200 request is processed and returned as a context meaning it is not possible to process the contents of a 404 error page, or login/registration forms returned with a status of 400 or 422, rather than 200 OK status. 

This was raised as [issue#56](https://github.com/LearnBoost/tobi/issues/56)

This patch handles "redirect" status responses before receiving and parsing the data for all other response codes.

It passes all of the current tests as well as the new 404 test page.
