### PR TITLE
External site redirecting back to app creates new browser instance

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -30,6 +30,7 @@ var startingPort = 9000;
  * Options:
  *
  *    - `external`   enable fetching and evaluation of external resources [false]
+ *    - `externalHost`   hostname if redirect back to from external site [undefined]
  *
  * @param {String|http.Server|Number} html
  * @param {Object|String} options
@@ -47,6 +48,7 @@ var Browser = module.exports = exports = function Browser(html, options, c) {
   // Initialize
   options = options || {};
   this.external = options.external;
+  this.externalHost = options.externalHost;
   this.history = [];
   this.cookieJar = new CookieJar;
   this.followRedirects = true;
@@ -133,6 +135,10 @@ Browser.prototype.hostBrowser = function(uri) {
     , otherBrowser;
   if (!browsers) {
     browsers = Browser.browsers = {};
+  }
+  // If we are redirected back, use the same browser
+  if (browsers['undefined'] && browsers['undefined'].externalHost == otherHostname) {
+      otherHostname = 'undefined';
   }
   if (!browsers[this.host]) {
     browsers[this.host] = this;

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -278,7 +278,7 @@ module.exports = {
       var googBrowser = Browser.browsers['github.com']
       googBrowser.should.have.property('path', '/');
       googBrowser.history.should.eql(['/']);
-      googBrowser.jQuery('img[alt="github"]').should.not.be.empty;
+      googBrowser.jQuery('img[alt="GitHub"]').should.not.be.empty;
       done();
     });
   },
@@ -313,7 +313,7 @@ module.exports = {
       Browser.browsers.should.have.property('bit.ly');
       Browser.browsers.should.have.property('nodejs.org');
       var nodeBrowser = Browser.browsers['nodejs.org'];
-      nodeBrowser.jQuery('img[alt="node.js"]').length.should.equal(1);
+      nodeBrowser.jQuery('img[alt="node.js"]').length.should.equal(2);
       done();
     });
   },

--- a/test/browser.navigation.test.js
+++ b/test/browser.navigation.test.js
@@ -42,6 +42,10 @@ app.get('/redirect', function(req, res){
   res.redirect('/one');
 });
 
+app.get('/redirect/external', function(req, res){
+  res.redirect('http://bit.ly/mQETJ8');
+});
+
 app.get('/xml', function(req, res){
   res.contentType('.xml');
   res.send('<user><name>tj</name></user>');
@@ -315,6 +319,25 @@ module.exports = {
       var nodeBrowser = Browser.browsers['nodejs.org'];
       nodeBrowser.jQuery('img[alt="node.js"]').length.should.equal(2);
       done();
+    });
+  },
+
+  'test .request() redirect to a full uri and back again to app': function(done) {
+    Browser.browsers = {}
+    // Use externalHost to pretend to be nodejs.org
+    // The app redirects us out to bit.ly which redirects us back
+    var browser = tobi.createBrowser(app, {externalHost: 'nodejs.org'});
+    browser.followRedirects = false;
+    browser.request('GET', '/redirect/external', {}, function(res, $){
+      res.should.have.status(301);
+      Browser.browsers.should.have.property('bit.ly');
+      Browser.browsers.should.have.property('undefined');
+      browser.request('GET', res.headers['location'], {}, function(res, $){
+        res.should.have.status(200);
+        Browser.browsers.should.not.have.property('nodejs.org');
+        $('p').should.have.text('Hello World');
+        done();
+      });
     });
   },
 

--- a/test/jquery.test.js
+++ b/test/jquery.test.js
@@ -19,7 +19,7 @@ module.exports = {
       + '<input type="radio" name="signature" value="hide" />'
       + '<input type="checkbox" name="agreement" value="ageed" />'
       + '<input type="checkbox" name="email" value="yes" checked="checked" />'
-      + '<select name="province">'
+      + '<select name="province" multiple="true">'
       + '  <option value="bc">British Columbia</option>'
       + '  <option value="ab">Alberta</option>'
       + '</select>'


### PR DESCRIPTION
Example use case:

Testing facebook authentication for web sites:
- browser requests '/auth/facebook' which redirects to app authentication flow
- browser logs into facebook and is redirected back to application

Current behaviour:
- Because the host name doesn't match 'undefined' a new browser is created; the cookies are not transferred, session information is lost.

Expected behaviour:
- Reuse the same browser object used for the initial request to the app. I.e., 'undefined'

Notes:
- If you are passing an app to Browser, then the host argument is ignored. Attempted to set self.host for this purpose but it caused all sorts of woes.
- Added new option externalHost for the hostname of the 'undefined' browser
