### PR TITLE
Fixed URL port type casting issue

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -128,7 +128,7 @@ Browser.prototype.context = function(selector, fn){
 
 Browser.prototype.hostBrowser = function(uri) {
   var otherHostname = uri.hostname
-    , port = uri.port || (uri.protocol === 'https:' ? 443 : (this.port || 80))
+    , port = parseInt(uri.port,10) || (uri.protocol === 'https:' ? 443 : (this.port || 80))
     , browsers = Browser.browsers
     , otherBrowser;
   if (!browsers) {


### PR DESCRIPTION
Browser expects port in options to be typeof number (browser.js:55), however url#parse returns string. This caused URLs with port number to break.
