### PR TITLE
Use default host in request when not specified

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -216,7 +216,7 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
       method: method
     , path: path
     , port: this.host ? this.port : (server && server.__port)
-    , host: this.host
+    , host: host
     , headers: headers
   });
   req.on('response', function(res){


### PR DESCRIPTION
The http request was being invoked with an undefined host. This was freaking `nock` out. I think this is probably what is intended.
