### PR TITLE
Cookie attribute name should be case-insensitively parsed.

### DIFF
--- a/lib/cookie/index.js
+++ b/lib/cookie/index.js
@@ -28,7 +28,7 @@ var Cookie = exports = module.exports = function Cookie(str, req) {
   // Map the key/val pairs
   str.split(/ *; */).reduce(function(obj, pair){
     pair = pair.split(/ *= */);
-    obj[pair[0]] = pair[1] || true;
+    obj[pair[0].toLowerCase()] = pair[1] || true;
     return obj;
   }, this);
 


### PR DESCRIPTION
Need this patch when the server returns a cookie that has upper-case chars in the start of attribute names like this:

  [ 'sessionkey=value; Domain=.dev.speedland.net; Path=/; Expires=Sat, 27 Apr 2013 07:57:05 GMT; HttpOnly' ]

I found this type of cookie response in express 3.0. 

In RFC6265, these attribute names can be case-insensitive. (See the 'Path' case: http://tools.ietf.org/html/rfc6265#section-5.2.4)
