### PR TITLE
Feature/self signed ssl support

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -212,13 +212,26 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
   }
 
   // Request
-  var req = (this.https ? https : http).request({
+  var reqOpts = {
       method: method
     , path: path
     , port: this.host ? this.port : (server && server.__port)
     , host: this.host
     , headers: headers
-  });
+  };
+  var req;
+  if (this.https){
+    if( options.tlsOpts ){
+      ["pfx", "key", "passphrase", "cert", "ca", "ciphers", "rejectUnauthorized"].forEach(function(name){
+        if( options.tlsOpts[name] !== undefined ){
+          reqOpts[name] = options.tlsOpts[name];
+        }
+      });
+    }
+    req = https.request(reqOpts);
+  }else{
+    req = http.request(reqOpts);
+  }
   req.on('response', function(res){
     var status = res.statusCode
       , buf = '';

--- a/lib/cookie/index.js
+++ b/lib/cookie/index.js
@@ -28,7 +28,7 @@ var Cookie = exports = module.exports = function Cookie(str, req) {
   // Map the key/val pairs
   str.split(/ *; */).reduce(function(obj, pair){
     pair = pair.split(/ *= */);
-    obj[pair[0]] = pair[1] || true;
+    obj[pair[0].toLowerCase()] = pair[1] || true;
     return obj;
   }, this);
 


### PR DESCRIPTION
From Node 0.10.0, when we use https, rejectUnauthorized is false by default (https://github.com/joyent/node/issues/3949) so that we need to configure this option when we use tobi against the server with self-signed certification.

This patch make it enable to configure TLS options in https request including rejectUnauthorized.
