### PR TITLE
support to take tls options for a request.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -212,13 +212,26 @@ Browser.prototype.request = function(method, path, options, fn, saveHistory){
   }
 
   // Request
-  var req = (this.https ? https : http).request({
+  var reqOpts = {
       method: method
     , path: path
     , port: this.host ? this.port : (server && server.__port)
     , host: this.host
     , headers: headers
-  });
+  };
+  var req;
+  if (this.https){
+    if( options.tlsOpts ){
+      ["pfx", "key", "passphrase", "cert", "ca", "ciphers", "rejectUnauthorized"].forEach(function(name){
+        if( options.tlsOpts[name] !== undefined ){
+          reqOpts[name] = options.tlsOpts[name];
+        }
+      });
+    }
+    req = https.request(reqOpts);
+  }else{
+    req = http.request(reqOpts);
+  }
   req.on('response', function(res){
     var status = res.statusCode
       , buf = '';


### PR DESCRIPTION
From Node 0.10.0, when we use https, rejectUnauthorized is false by default (joyent/node#3949) so that we need to configure this option when we use tobi against the server with self-signed certification.

This patch make it enable to configure TLS options in https request including rejectUnauthorized.
